### PR TITLE
Corrected the port for monasca-api

### DIFF
--- a/events_func_test.py
+++ b/events_func_test.py
@@ -22,9 +22,9 @@ import uuid
 from monascaclient import ksclient
 
 
-events_base_url = "http://127.0.0.1:8082"
-# events_base_url = "http://192.168.10.4:8082"
-notifications_base_url = "http://192.168.10.4:8080"
+# events_base_url = "http://127.0.0.1:8082"
+events_base_url = "http://192.168.10.4:8082"
+notifications_base_url = "http://192.168.10.4:8070"
 
 
 event_compute_start = {


### PR DESCRIPTION
The port for monasca-api has changed, and
defaulted the events api url for mini-mon